### PR TITLE
iGenomes base path (temporary) fix

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
 
     // Genome and reference options
     genome                          = 'GRCh38'
-    igenomes_base                   = 's3://ngi-igenomes/igenomes/'
+    igenomes_base                   = 's3://ngi-igenomes/igenomes'
     igenomes_ignore                 = false
     save_reference                  = false
     build_only_index                = false // Only build the reference indexes


### PR DESCRIPTION
Using iGenomes reference FASTA file caused the following error:

```
ERROR ~ Cannot invoke method endsWith() on null object

 -- Check script '/.../.nextflow/assets/nf-core/rnadnavar/./workflows/../subworkflows/local/prepare_reference_and_intervals/./../prepare_genome/main.nf' at line: 55 or see '.nextflow.log' file for more details
The sample-sheet only contains normal-samples, but the following tools, which were requested with "--tools", expect at least one tumor-sample : mutect2
```

I found that the double forward slash `//` in the generated iGenomes paths caused related parameters to be loaded as `null`. I fixed it by removing the `/` from iGenomes base path in `nextflow.config`.

I have not checked all the boxes below, bacause the pipeline throws a bunch of errors (maybe caused by migration to nf-core 3?) that should be addressed [elsewhere](https://github.com/nf-core/rnadnavar/issues/44#issue-2632880132).

<!--
# nf-core/rnadnavar pull request

Many thanks for contributing to nf-core/rnadnavar!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnadnavar/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnadnavar/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnadnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
