### PR TITLE
Fixing channel of gzi in MERGE_CRAM

### DIFF
--- a/subworkflows/local/bam_applybqsr/main.nf
+++ b/subworkflows/local/bam_applybqsr/main.nf
@@ -35,7 +35,7 @@ workflow BAM_APPLYBQSR {
     cram_to_merge = GATK4_APPLYBQSR.out.cram.map{ meta, c -> [ groupKey(meta, meta.num_intervals), c ] }.groupTuple()
     cram_to_merge.dump(tag:"cram_to_merge1")
     // Merge and index the recalibrated cram files
-    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta, fasta_fai)
+    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta.map{_meta, fa -> fa}, fasta_fai)
 
     cram_recal = CRAM_MERGE_INDEX_SAMTOOLS.out.cram_crai
         // Remove no longer necessary field: num_intervals

--- a/subworkflows/local/bam_splitncigarreads/main.nf
+++ b/subworkflows/local/bam_splitncigarreads/main.nf
@@ -34,7 +34,7 @@ workflow BAM_SPLITNCIGARREADS {
     cram_to_merge = GATK4_SPLITNCIGARREADS.out.cram.map{ meta, crm -> [ groupKey(meta, meta.num_intervals), crm ] }.groupTuple()
 
     // Merge and index the recalibrated cram files
-    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta, fasta_fai)
+    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta.map{_meta, fa -> fa}, fasta_fai)
 
     cram_recal = CRAM_MERGE_INDEX_SAMTOOLS.out.cram_crai
     // Remove no longer necessary field: num_intervals

--- a/subworkflows/local/bam_splitncigarreads/main.nf
+++ b/subworkflows/local/bam_splitncigarreads/main.nf
@@ -34,7 +34,7 @@ workflow BAM_SPLITNCIGARREADS {
     cram_to_merge = GATK4_SPLITNCIGARREADS.out.cram.map{ meta, crm -> [ groupKey(meta, meta.num_intervals), crm ] }.groupTuple()
 
     // Merge and index the recalibrated cram files
-    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta.map{_meta, fa -> fa}, fasta_fai)
+    CRAM_MERGE_INDEX_SAMTOOLS(cram_to_merge, fasta.map{_meta, fa -> fa}, fasta_fai.map{_meta, fai -> fai})
 
     cram_recal = CRAM_MERGE_INDEX_SAMTOOLS.out.cram_crai
     // Remove no longer necessary field: num_intervals

--- a/subworkflows/local/cram_merge_index_samtools/main.nf
+++ b/subworkflows/local/cram_merge_index_samtools/main.nf
@@ -25,7 +25,7 @@ workflow CRAM_MERGE_INDEX_SAMTOOLS {
     }
 
     // Only when using intervals
-    MERGE_CRAM(cram_to_merge.multiple, fasta.map{ it -> [ [ id:'fasta' ], it ] }, fasta_fai.map{ it -> [ [ id:'fasta_fai' ], it ] }, [])
+    MERGE_CRAM(cram_to_merge.multiple, fasta.map{ it -> [ [ id:'fasta' ], it ] }, fasta_fai.map{ it -> [ [ id:'fasta_fai' ], it ] }, [[id: 'gzi'], []])
 
     // Mix intervals and no_intervals channels together
     cram_all = MERGE_CRAM.out.cram.mix(cram_to_merge.single)


### PR DESCRIPTION
The new module asks for a gzi channel with meta, the default is empty, but the meta was not specified.
