### PR TITLE
Fix BAM grouping failure due to lane field in metadata

### DIFF
--- a/subworkflows/local/bam_align/main.nf
+++ b/subworkflows/local/bam_align/main.nf
@@ -144,7 +144,7 @@ workflow BAM_ALIGN {
             }
             // Manipulate meta map to remove old fields and add new ones
             .map { meta, bam ->
-                [ meta - meta.subMap('id', 'read_group', 'data_type', 'num_lanes', 'read_group', 'size') + [ data_type: 'bam', id: meta.sample ], bam ]
+                [ meta - meta.subMap('id', 'read_group', 'data_type', 'num_lanes', 'read_group', 'size', 'lane') + [ data_type: 'bam', id: meta.sample ], bam ]
             }
             // Create groupKey from meta map
             .map { meta, bam ->
@@ -176,7 +176,7 @@ workflow BAM_ALIGN {
             }
             // Manipulate meta map to remove old fields and add new ones
             .map { meta, bam ->
-                [ meta - meta.subMap('id', 'read_group', 'data_type', 'num_lanes', 'read_group', 'size') + [ data_type: 'bam', id: meta.sample ], bam ]
+                [ meta - meta.subMap('id', 'read_group', 'data_type', 'num_lanes', 'read_group', 'size', 'lane') + [ data_type: 'bam', id: meta.sample ], bam ]
             }
             // Create groupKey from meta map
             .map { meta, bam ->

--- a/subworkflows/local/utils_nfcore_rnadnavar_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnadnavar_pipeline/main.nf
@@ -207,7 +207,7 @@ def toolCitationText() {
     // Build text sections for different pipeline components
     def text_preprocessing = [
         "Raw read quality control was performed with FastQC (Andrews 2010)",
-        params.params.trim_fastq || params.split_fastq > 0 ? "and preprocessing with fastp (Chen et al. 2018)." : "."
+        params.trim_fastq || params.split_fastq > 0 ? "and preprocessing with fastp (Chen et al. 2018)." : "."
     ].join(' ').trim()
 
     def text_alignment = [

--- a/subworkflows/local/utils_nfcore_rnadnavar_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnadnavar_pipeline/main.nf
@@ -207,7 +207,7 @@ def toolCitationText() {
     // Build text sections for different pipeline components
     def text_preprocessing = [
         "Raw read quality control was performed with FastQC (Andrews 2010)",
-        params.trimmer == "fastp" ? "and preprocessing with fastp (Chen et al. 2018)." : "."
+        params.params.trim_fastq || params.split_fastq > 0 ? "and preprocessing with fastp (Chen et al. 2018)." : "."
     ].join(' ').trim()
 
     def text_alignment = [
@@ -274,7 +274,7 @@ def toolBibliographyText() {
     // Quality control and preprocessing
     def qc_preprocessing_citations = [
         "<li>Andrews, S. (2010). FastQC: A Quality Control Tool for High Throughput Sequence Data [Online]. Available: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</li>",
-        params.trimmer == "fastp" ? "<li>Chen S, Zhou Y, Chen Y, Gu J. fastp: an ultra-fast all-in-one FASTQ preprocessor. Bioinformatics. 2018 Sep 1;34(17):i884-i890. <a href=\"https://doi.org/10.1093/bioinformatics/bty560\">10.1093/bioinformatics/bty560</a></li>" : ""
+        params.trim_fastq || params.split_fastq > 0 ? "<li>Chen S, Zhou Y, Chen Y, Gu J. fastp: an ultra-fast all-in-one FASTQ preprocessor. Bioinformatics. 2018 Sep 1;34(17):i884-i890. <a href=\"https://doi.org/10.1093/bioinformatics/bty560\">10.1093/bioinformatics/bty560</a></li>" : ""
     ].join(' ').trim()
 
     // Alignment tools


### PR DESCRIPTION
**Problem:**

DNA BAMs were not progressing past the groupTuple() operation, causing the pipeline to hang indefinitely. The issue affected DNA samples with multiple lanes (L001, L002, L003). The issue was as follows:

1. The `groupTuple()` operator groups items by the entire metadata map, not just some fields
2. The `lane` field was still present in the metadata when creating the `groupKey`.
3. This caused BAMs from the same sample to be split into separate groups based on their lane and not progress as they did not meet the condition to continue (based on the expected number of BAM files).

**Solution:**

Remove the `lane` field from metadata in the appropriate local subworkflow (`BAM_ALIGN`) before creating the `groupKey`, ensuring all BAMs from the same sample group together correctly regardless of lane.
